### PR TITLE
Hour timestamp support

### DIFF
--- a/skins/template.js
+++ b/skins/template.js
@@ -109,13 +109,15 @@
      */
     function formatTime ( seconds ) {
 
-        var date = new Date( seconds*1000 ),
-            minutes = date.getMinutes(),
-            seconds = date.getSeconds();
+        var date = new Date( seconds * 1000 ),
+            hours = date.getUTCHours(),
+            minutes = date.getUTCMinutes(),
+            seconds = date.getUTCSeconds();
 
-        return (minutes < 10 ? '0': '')+minutes
-            +':'
-            +(seconds < 10 ? '0': '')+seconds;
+        return (hours > 0 ? hours + ':' : '')
+            + (minutes < 10 ? '0' : '') + minutes
+            + ':'
+            + (seconds < 10 ? '0' : '') + seconds;
     }
 
     var pluxbox = PB.Class(/* PB.Player.Skin, */ {


### PR DESCRIPTION
Added support for hour timestamp and changed to getUTC, as a UTC Unix
timestamp is used for input (important when working with hours, and to a
lesser extend minutes).

Only changed the javascript (no flash)
